### PR TITLE
OT135-34-retries-a

### DIFF
--- a/dag-universities-a.py
+++ b/dag-universities-a.py
@@ -2,12 +2,18 @@ from datetime import timedelta, datetime
 from airflow import DAG
 from airflow.operators.dummy import DummyOperator
 
+default_args = {
+    'retries': 1,
+    'retry_delay': timedelta(minutes=5)
+}
+
 # Instanciamos dag
 with DAG(
     'dag_universities_a',
-    description = 'DAG para la Universidad De Flores y Universidad Nacional De Villa María. Documenta los operators que se utilizan a futuro, teniendo en cuenta que se va a hacer una consulta SQL, se van a procesar los datos con pandas y se van a cargar los datos en S3',
-    schedule_interval = timedelta(hours=1),
-    start_date = datetime(2022, 1, 26),
+    default_args=default_args,
+    description='DAG para la Universidad De Flores y Universidad Nacional De Villa María. Documenta los operators que se utilizan a futuro, teniendo en cuenta que se va a hacer una consulta SQL, se van a procesar los datos con pandas y se van a cargar los datos en S3',
+    schedule_interval=timedelta(hours=1),
+    start_date=datetime(2022, 1, 26),
 ) as dag:
     query_sql = DummyOperator(task_id='query_sql') # Consulta SQL
     pandas_process = DummyOperator(task_id='pandas_process') # Procesar datos con pandas


### PR DESCRIPTION
# Retries para grupo de universidades A
Se configuraron los retries para la posterior conexión a la base de datos de la Universidad de Flores y Universidad Nacional de Villa María.
* Se crea la variable default_args con los parámetros de retries y retry_delay y se agrega a los parámetros de dag.
* Se eliminan los espacios que existían en los parámetros del dag.

[Link](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT135/boards/208?modal=detail&selectedIssue=OT135-34&assignee=61eea96725edab006af93e59)