### PR TITLE
OT135-49-logging-h

### DIFF
--- a/dag-universities-h.py
+++ b/dag-universities-h.py
@@ -1,6 +1,14 @@
+import logging
+
 from airflow import DAG
 from datetime import timedelta, datetime
 from airflow.operators.dummy import DummyOperator
+
+logging.basicConfig(
+    level=logging.ERROR,
+    format='%(asctime)s - %(module)s - %(message)s',
+    datefmt='%Y-%m-%d'
+)
 
 # instanciamos dag   
 with DAG(


### PR DESCRIPTION
# Configuración de logs para el grupo de universidades H
Se realiza una configuración de logging para la Universidad del Cine y la Universidad de Buenos Aires.
* Se importa la librería logging
* Se realiza un logging.configBasic() con los parámetros de:
  - El nivel del logging seteado en ERROR.
  - Se establece el formato de salida de consola configurando el asctime en "%Y-%m-%d"
  
[Link](https://alkemy-labs.atlassian.net/jira/software/c/projects/OT135/boards/208?modal=detail&selectedIssue=OT135-49&assignee=61eea96725edab006af93e59)